### PR TITLE
Have the container fullfill the space of it's parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,6 +191,7 @@ class SwipeAbleDrawer extends Component {
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     backgroundColor: '#dedede',
   },
   drawer: {


### PR DESCRIPTION
If there is a soft navigation keys for the Android device. The front style that using `height: height` will have some part of the front view covered by the navigation keys. Just shown in the following image. There should be a 10unit margin to the bottom of the view.
```javascript
      <ScalingDrawer
        ref={ref => (this.drawer = ref)}
        content={<SideMenu navigate={this.navigate} closeDrawer={this.closeDrawer} />}
        scalingFactor={scalingFactor}
        minimizeFactor={minimizeFactor}>
        <View style={{ flex: 1, backgroundColor: 'red', margin: 10 }} />
      </ScalingDrawer>
```
![](https://i.loli.net/2018/03/19/5aaf6103aa400.png)

Please add `flex: 1` to style of the container to make it possible to make the front be visible totally by overriding the frontStyle with `frontStyle={{ flex: 1, height: undefined }}`
```javascript
<ScalingDrawer
        ref={ref => (this.drawer = ref)}
        content={<SideMenu navigate={this.navigate} closeDrawer={this.closeDrawer} />}
        frontStyle={{ flex: 1, height: undefined }}
        scalingFactor={scalingFactor}
        minimizeFactor={minimizeFactor}>
        <View style={{ flex: 1, backgroundColor: 'red', margin: 10 }} />
      </ScalingDrawer>
```
![](https://i.loli.net/2018/03/19/5aaf664863cdb.png)