### PR TITLE
Fix android height

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,12 @@ import {
   Animated,
   PanResponder,
   Dimensions,
+  StatusBar,
   Easing
 } from 'react-native';
-const {width, height} = Dimensions.get('window');
+
+const {width} = Dimensions.get('window');
+const height = Platform.OS === 'android' ? Dimensions.get('screen').height - StatusBar.currentHeight : Dimensions.get('window').height;
 
 class SwipeAbleDrawer extends Component {
   static defaultProps = {


### PR DESCRIPTION
Some android devices don't get the right height using "Dimensions". 
Check it out: https://github.com/facebook/react-native/issues/23693

Just did a validation to get the right height on all android devices.